### PR TITLE
SystemUI: allow volume panel to be moved to the left side.

### DIFF
--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -20,6 +20,8 @@
 <!-- These resources are around just to allow their values to be customized
      for different hardware and product builds. -->
 <resources>
+     <!-- Allow devices override audio panel location to the left side -->
+     <bool name="config_audioPanelOnLeftSide">false</bool>
     <!-- Whether to clip notification contents with a rounded rectangle. Might be expensive on
          certain GPU's and thus can be turned off with only minimal visual impact. -->
     <bool name="config_notifications_round_rect_clipping">true</bool>


### PR DESCRIPTION
Some devices have volume buttons on left side and it not fancy if volume panel will be at right side.
You can override panel location using overlay for SystemUI:

<!-- Allow devices override audio panel location to the left side -->
<bool name="config_audioPanelOnLeftSide">true</bool>

Change-Id: I273061a84847d2ad9dcda028d6c407c98841647b

Also includes:

commit f25ce242d9d0ca29d663d79ccb74ebbed02144c3 (HEAD -> pie)
Author: Alex Cruz <alex@dirtyunicorns.com>
Date:   Fri Dec 21 22:08:52 2018 -0600

    Volume panel: Do the same with less

    Change-Id: If41456f71ffd18466166e7b4120ff34d9e6f5a46

commit 80fd436c97cb0eda45bd488cdd3ce23b2d1ba141
Author: Kshitij Gupta <kshitijgm@gmail.com>
Date:   Wed Dec 26 15:46:18 2018 +0000

    VolumeDialogImpl: Fix animation direction logic

    - This behaviour was changed in PotatoProject/frameworks_base@f6f7826
    - Correct animation direction for better UX

    Change-Id: Ie036be0d3ac895d5de76040ecc8027036fb0ad3b
    Signed-off-by: Jagrav Naik <jagravnaik0@gmail.com>
    Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>