### PR TITLE
SystemUI: allow volume panel to be moved to the left side.

### DIFF
--- a/packages/SystemUI/res/layout/volume_dialog.xml
+++ b/packages/SystemUI/res/layout/volume_dialog.xml
@@ -19,8 +19,6 @@
     android:id="@+id/volume_dialog_container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:gravity="right"
-    android:layout_gravity="right"
     android:background="@android:color/transparent"
     android:theme="@style/qs_theme">
 
@@ -30,8 +28,6 @@
         android:minWidth="@dimen/volume_dialog_panel_width"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="right"
-        android:layout_gravity="right"
         android:background="@android:color/transparent"
         android:paddingRight="@dimen/volume_dialog_panel_transparent_padding_right"
         android:paddingTop="@dimen/volume_dialog_panel_transparent_padding"
@@ -65,7 +61,6 @@
             <include layout="@layout/volume_dnd_icon"
                      android:layout_width="match_parent"
                      android:layout_height="wrap_content"
-                     android:layout_marginRight="@dimen/volume_dialog_stream_padding"
                      android:layout_marginTop="6dp"/>
         </FrameLayout>
 
@@ -141,7 +136,6 @@
         android:layout="@layout/volume_tool_tip_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom | right"
         android:layout_marginRight="@dimen/volume_tool_tip_right_margin"
         android:layout_marginBottom="@dimen/volume_tool_tip_bottom_margin"/>
 

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -20,6 +20,8 @@
 <!-- These resources are around just to allow their values to be customized
      for different hardware and product builds. -->
 <resources>
+     <!-- Allow devices override audio panel location to the left side -->
+     <bool name="config_audioPanelOnLeftSide">false</bool>
     <!-- Whether to clip notification contents with a rounded rectangle. Might be expensive on
          certain GPU's and thus can be turned off with only minimal visual impact. -->
     <bool name="config_notifications_round_rect_clipping">true</bool>

--- a/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/VolumeDialogImpl.java
@@ -163,7 +163,9 @@ public class VolumeDialogImpl implements VolumeDialog,
     private boolean mHasSeenODICaptionsTooltip;
     private ViewStub mODICaptionsTooltipViewStub;
     private View mODICaptionsTooltipView = null;
-
+    
+    private boolean mLeftVolumeRocker;
+    
     public VolumeDialogImpl(Context context) {
         mContext =
                 new ContextThemeWrapper(context, R.style.qs_theme);
@@ -175,6 +177,7 @@ public class VolumeDialogImpl implements VolumeDialog,
         mShowActiveStreamOnly = showActiveStreamOnly();
         mHasSeenODICaptionsTooltip =
                 Prefs.getBoolean(context, Prefs.Key.HAS_SEEN_ODI_CAPTIONS_TOOLTIP, false);
+        mLeftVolumeRocker = mContext.getResources().getBoolean(R.bool.config_audioPanelOnLeftSide);
     }
 
     @Override
@@ -222,7 +225,11 @@ public class VolumeDialogImpl implements VolumeDialog,
         lp.format = PixelFormat.TRANSLUCENT;
         lp.setTitle(VolumeDialogImpl.class.getSimpleName());
         lp.windowAnimations = -1;
-        lp.gravity = mContext.getResources().getInteger(R.integer.volume_dialog_gravity);
+        if(!isAudioPanelOnLeftSide()){
+            lp.gravity = Gravity.RIGHT | Gravity.CENTER_VERTICAL;
+        } else {
+            lp.gravity = Gravity.LEFT | Gravity.CENTER_VERTICAL;
+        }
         mWindow.setAttributes(lp);
         mWindow.setLayout(WRAP_CONTENT, WRAP_CONTENT);
 
@@ -231,7 +238,7 @@ public class VolumeDialogImpl implements VolumeDialog,
         mDialogView.setAlpha(0);
         mDialog.setCanceledOnTouchOutside(true);
         mDialog.setOnShowListener(dialog -> {
-            if (!isLandscape()) mDialogView.setTranslationX(mDialogView.getWidth() / 2.0f);
+            if (!isLandscape()) mDialogView.setTranslationX((mDialogView.getWidth() / 2.0f)*(isAudioPanelOnLeftSide() ? -1 : 1));
             mDialogView.setAlpha(0);
             mDialogView.animate()
                     .alpha(1)
@@ -262,6 +269,11 @@ public class VolumeDialogImpl implements VolumeDialog,
         if (mRinger != null) {
             mRingerIcon = mRinger.findViewById(R.id.ringer_icon);
             mZenIcon = mRinger.findViewById(R.id.dnd_icon);
+            if(!isAudioPanelOnLeftSide()) {
+                mRinger.setForegroundGravity(Gravity.RIGHT);
+            } else {
+                mRinger.setForegroundGravity(Gravity.LEFT);
+            }
         }
 
         mODICaptionsView = mDialog.findViewById(R.id.odi_captions);
@@ -271,9 +283,16 @@ public class VolumeDialogImpl implements VolumeDialog,
         mODICaptionsTooltipViewStub = mDialog.findViewById(R.id.odi_captions_tooltip_stub);
         if (mHasSeenODICaptionsTooltip && mODICaptionsTooltipViewStub != null) {
             mDialogView.removeView(mODICaptionsTooltipViewStub);
-            mODICaptionsTooltipViewStub = null;
-        }
+            mODICaptionsTooltipViewStub = null;        
+        }else if (mODICaptionsTooltipViewStub != null){
+            if(!isAudioPanelOnLeftSide()) {
+                mRinger.setForegroundGravity(Gravity.BOTTOM | Gravity.RIGHT);
+            } else {
+                mRinger.setForegroundGravity(Gravity.BOTTOM | Gravity.LEFT);
+            }
 
+        }
+                
         mSettingsView = mDialog.findViewById(R.id.settings_container);
         mSettingsIcon = mDialog.findViewById(R.id.settings);
 
@@ -349,7 +368,11 @@ public class VolumeDialogImpl implements VolumeDialog,
         if (D.BUG) Slog.d(TAG, "Adding row for stream " + stream);
         VolumeRow row = new VolumeRow();
         initRow(row, stream, iconRes, iconMuteRes, important, defaultStream);
-        mDialogRowsView.addView(row.view);
+        if(!isAudioPanelOnLeftSide()){
+            mDialogRowsView.addView(row.view, 0);
+        } else {
+            mDialogRowsView.addView(row.view);
+        }
         mRows.add(row);
     }
 
@@ -359,7 +382,11 @@ public class VolumeDialogImpl implements VolumeDialog,
             final VolumeRow row = mRows.get(i);
             initRow(row, row.stream, row.iconRes, row.iconMuteRes, row.important,
                     row.defaultStream);
-            mDialogRowsView.addView(row.view);
+            if(!isAudioPanelOnLeftSide()){
+                mDialogRowsView.addView(row.view, 0);
+            } else {
+                mDialogRowsView.addView(row.view);
+            }            
             updateVolumeRowH(row);
         }
     }
@@ -758,7 +785,7 @@ public class VolumeDialogImpl implements VolumeDialog,
                     tryToRemoveCaptionsTooltip();
                     mIsAnimatingDismiss = false;
                 }, 50));
-        if (!isLandscape()) animator.translationX(mDialogView.getWidth() / 2.0f);
+        if (!isLandscape()) animator.translationX((mDialogView.getWidth() / 2.0f)*(isAudioPanelOnLeftSide() ? -1 : 1));
         animator.start();
         checkODICaptionsTooltip(true);
         mController.notifyVisible(false);
@@ -1454,6 +1481,10 @@ public class VolumeDialogImpl implements VolumeDialog,
         }
     }
 
+    private boolean isAudioPanelOnLeftSide() {
+        return mLeftVolumeRocker;
+    }
+                
     private static class VolumeRow {
         private View view;
         private TextView header;


### PR DESCRIPTION
Some devices have volume buttons on left side and it not fancy if volume panel will be at right side.
You can override panel location using overlay for SystemUI:

<!-- Allow devices override audio panel location to the left side -->
<bool name="config_audioPanelOnLeftSide">true</bool>

Change-Id: I273061a84847d2ad9dcda028d6c407c98841647b

Also includes:

commit f25ce242d9d0ca29d663d79ccb74ebbed02144c3 (HEAD -> pie)
Author: Alex Cruz <alex@dirtyunicorns.com>
Date:   Fri Dec 21 22:08:52 2018 -0600

    Volume panel: Do the same with less

    Change-Id: If41456f71ffd18466166e7b4120ff34d9e6f5a46

commit 80fd436c97cb0eda45bd488cdd3ce23b2d1ba141
Author: Kshitij Gupta <kshitijgm@gmail.com>
Date:   Wed Dec 26 15:46:18 2018 +0000

    VolumeDialogImpl: Fix animation direction logic

    - This behaviour was changed in PotatoProject/frameworks_base@f6f7826
    - Correct animation direction for better UX

    Change-Id: Ie036be0d3ac895d5de76040ecc8027036fb0ad3b
    Signed-off-by: Jagrav Naik <jagravnaik0@gmail.com>
    Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>

