### PR TITLE
base: Grant battery stats reset permission to Settings

### DIFF
--- a/data/etc/com.android.settings.xml
+++ b/data/etc/com.android.settings.xml
@@ -20,6 +20,7 @@
         <permission name="android.permission.ACCESS_NOTIFICATIONS"/>
         <permission name="android.permission.BACKUP"/>
         <permission name="android.permission.BATTERY_STATS"/>
+        <permission name="android.permission.RESET_BATTERY_STATS"/>
         <permission name="android.permission.BLUETOOTH_PRIVILEGED"/>
         <permission name="android.permission.CHANGE_APP_IDLE_STATE"/>
         <permission name="android.permission.CHANGE_CONFIGURATION"/>


### PR DESCRIPTION
At least for me the rom was building correctly but cannot boot (it stops at animation)