### PR TITLE
Netflix HDR fixed

### DIFF
--- a/core/java/com/android/internal/util/custom/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/custom/PixelPropsUtils.java
@@ -32,6 +32,7 @@ public class PixelPropsUtils {
     public static final String PACKAGE_GMS = "com.google.android.gms";
     private static final String DEVICE = "org.pixelexperience.device";
     private static final String TAG = PixelPropsUtils.class.getSimpleName();
+    public static final String PACKAGE_NETFLIX = "com.netflix.mediaclient";
     private static final boolean DEBUG = false;
 
     private static final Map<String, Object> propsToChangePixel6;
@@ -56,7 +57,8 @@ public class PixelPropsUtils {
     private static final String[] extraPackagesToChange = {
             "com.android.chrome",
             "com.android.vending",
-            "com.breel.wallpapers20"
+            "com.breel.wallpapers20",
+            PACKAGE_NETFLIX
     };
 
     private static final String[] packagesToKeep = {
@@ -128,6 +130,13 @@ public class PixelPropsUtils {
                 processName.equals(PACKAGE_GMS + ".unstable")) {
             sIsGms = true;
         }
+
+        if (packageName.equals(PACKAGE_NETFLIX) && !SystemProperties.getBoolean(
+                "persist.pixelpropsutils.spoof_netflix", true)) {
+            if (DEBUG) Log.d(TAG, "Netflix spoofing disabled by system prop");
+            return;
+        }
+
         boolean isPixelDevice = Arrays.asList(pixelCodenames).contains(SystemProperties.get(DEVICE));
         if (!isPixelDevice && 
             ((packageName.startsWith("com.google.") && !Arrays.asList(packagesToKeep).contains(packageName))


### PR DESCRIPTION
- Disabled spoofing by default, say, the device supports
   Dolby Vision or has horrible (tinted) HDR, set
   persist.pixelpropsutils.spoof_netflix to enable it.